### PR TITLE
chore: publish v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## [2.0.0] - 2022-12-16
+
 ### Changed
 
 - **BREAKING CHANGE**: The minimum supported version of Node is now Node.JS 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nqminds/nqm-tdx-terminal-cli",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nqminds/nqm-tdx-terminal-cli",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@nqminds/nqm-api-tdx": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nqminds/nqm-tdx-terminal-cli",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Command-line interface for accessing the TDX API",
   "main": "main.js",
   "directories": {


### PR DESCRIPTION
Publish version `2.0.0` of `@nqminds/nqm-tdx-terminal-cli`

# CHANGELOG

Changed
-------

- **BREAKING CHANGE**: The minimum supported version of Node is now Node.JS 16.

Dependencies
------------

- Removed `@nqminds/nqm-databot-utils` as a dependency